### PR TITLE
Add support for GCP bucket storage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install aiopmtiles
         run: |
           python -m pip install --upgrade pip
-          python -m pip install .["test","aws"]
+          python -m pip install .["test","aws","gcp"]
 
       - name: run pre-commit
         if: ${{ matrix.python-version == env.LATEST_PY_VERSION }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Issues and pull requests are more than welcome.
 ```bash
 $ git clone https://github.com/developmentseed/aiopmtiles.git
 $ cd aiopmtiles
-$ python -m pip install -e .["test","dev","aws"]
+$ python -m pip install -e .["test","dev","aws","gcp"]
 ```
 
 You can then run the tests with the following command:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,10 @@ dependencies = [
 aws = [
     "aioboto3"
 ]
+gcp = [
+    "gcloud-aio-auth",
+    "gcloud-aio-storage"
+]
 test = [
     "pytest",
     "pytest-cov",
@@ -70,9 +74,9 @@ parallel = true
 
 [tool.coverage.report]
 exclude_lines = [
-  "no cov",
-  "if __name__ == .__main__.:",
-  "if TYPE_CHECKING:",
+    "no cov",
+    "if __name__ == .__main__.:",
+    "if TYPE_CHECKING:",
 ]
 
 [tool.isort]

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -4,7 +4,13 @@ import os
 
 import pytest
 
-from aiopmtiles.io import FileSystem, HttpFileSystem, LocalFileSystem, S3FileSystem
+from aiopmtiles.io import (
+    FileSystem,
+    GcsFileSystem,
+    HttpFileSystem,
+    LocalFileSystem,
+    S3FileSystem,
+)
 
 FIXTURES_DIR = os.path.join(os.path.dirname(__file__), "fixtures")
 VECTOR_PMTILES = os.path.join(FIXTURES_DIR, "protomaps(vector)ODbL_firenze.pmtiles")
@@ -16,6 +22,7 @@ VECTOR_PMTILES = os.path.join(FIXTURES_DIR, "protomaps(vector)ODbL_firenze.pmtil
         ("myfile.pmtiles", LocalFileSystem),
         ("file:///myfile.pmtiles", LocalFileSystem),
         ("s3://bucket/myfile.pmtiles", S3FileSystem),
+        ("gs://bucket/myfile.pmtiles", GcsFileSystem),
         ("http://url.io/myfile.pmtiles", HttpFileSystem),
         ("https://url.io/myfile.pmtiles", HttpFileSystem),
     ],


### PR DESCRIPTION
This adds support for GCP bucket storage, as it's part of the stack we use

Given that this project focuses on async flows, I've relied on the [gcloud-aio](https://github.com/talkiq/gcloud-aio) project rather than the official library (which doesn't have official aio support just yet)